### PR TITLE
Revert "Simplifying path normalization"

### DIFF
--- a/sia_load_tester/upload_queue.py
+++ b/sia_load_tester/upload_queue.py
@@ -59,7 +59,10 @@ def _dataset_to_jobs(input_dataset):
 
 
 def _local_path_to_sia_path(local_path, dataset_root_dir):
-    return os.path.normpath(os.path.relpath(local_path, dataset_root_dir))
+    sia_path = os.path.relpath(local_path, dataset_root_dir)
+    path_separator = os.path.sep
+    # Normalize to forward slash path separators.
+    return sia_path.replace(path_separator, '/')
 
 
 def _get_sia_local_paths(sia_client):

--- a/tests/test_upload_queue.py
+++ b/tests/test_upload_queue.py
@@ -14,6 +14,12 @@ class GenerateUploadQueueTest(unittest.TestCase):
         self.mock_sia_api_impl = mock.Mock()
         self.mock_sia_client = sc.SiaClient(
             self.mock_sia_api_impl, sleep_fn=mock.Mock())
+        # Save original path separator so that we can restore it after tests
+        # modify it.
+        self.original_path_sep = os.path.sep
+
+    def tearDown(self):
+        os.path.sep = self.original_path_sep
 
     def test_generates_empty_queue_when_all_files_already_on_sia(self):
         dummy_dataset = dataset.Dataset('/dummy-path', [
@@ -85,12 +91,10 @@ class GenerateUploadQueueTest(unittest.TestCase):
                 local_path='/dummy-root/fiz/baz/c.txt',
                 sia_path='fiz/baz/c.txt'), queue.get())
 
-    # Patch out path functions to simulate a Windows environment.
+    # Patch out relpath to simulate a Windows environment.
     @mock.patch.object(os.path, 'relpath')
-    @mock.patch.object(os.path, 'normpath')
-    def test_converts_path_separators_on_windows(self, normpath_patch,
-                                                 relpath_patch):
-        normpath_patch.side_effect = lambda p: p.replace('\\', '/')
+    def test_converts_path_separators_on_windows(self, relpath_patch):
+        os.path.sep = '\\'
         relpath_patch.side_effect = lambda p, _: p[len('C:\\dummy-root\\'):]
 
         input_dataset = dataset.Dataset(r'C:\dummy-root', [


### PR DESCRIPTION
Reverts mtlynch/sia_load_tester#24

This actually just preserves backslashes on Windows. The previous method was ugly, but worked.