### PR TITLE
Adding support for a --dataset_copies flag

### DIFF
--- a/sia_load_tester/jobs.py
+++ b/sia_load_tester/jobs.py
@@ -1,19 +1,40 @@
 import os
 
+# Limit to this many copies. Mainly for formatting siapaths cleanly.
+MAX_DATASET_COPIES = 100000000
 
-def from_dataset(input_dataset):
+
+class Error(Exception):
+    pass
+
+
+class InvalidCopyCountError(Error):
+    pass
+
+
+def from_dataset(input_dataset, dataset_copies):
     """Converts a Dataset to a list of Job instances.
 
     Args:
         input_dataset: The Dataset of files to upload to Sia.
+        dataset_copies: The number of times each file in the dataset should be
+            uploaded to Sia.
 
     Returns:
         A list of upload jobs.
     """
     jobs = []
-    for local_path in input_dataset.paths:
-        sia_path = _local_path_to_sia_path(local_path, input_dataset.root_dir)
-        jobs.append(Job(local_path, sia_path))
+    if dataset_copies < 1 or dataset_copies > MAX_DATASET_COPIES:
+        raise InvalidCopyCountError(
+            'dataset_copies must be an integer between 1 and %d. got: %d' %
+            (MAX_DATASET_COPIES, dataset_copies))
+    for copy_index in xrange(dataset_copies):
+        for local_path in input_dataset.paths:
+            sia_path = _local_path_to_sia_path(local_path,
+                                               input_dataset.root_dir)
+            if dataset_copies != 1:
+                sia_path = _append_file_index(sia_path, copy_index)
+            jobs.append(Job(local_path, sia_path))
     return jobs
 
 
@@ -22,6 +43,22 @@ def _local_path_to_sia_path(local_path, dataset_root_dir):
     path_separator = os.path.sep
     # Normalize to forward slash path separators.
     return sia_path.replace(path_separator, '/')
+
+
+def _append_file_index(sia_path, copy_index):
+    """Appends a file index to a Sia path to represent which copy this is.
+
+    Args:
+        sia_path: The original Sia path before the copy index is added.
+        copy_index: An index of which copy number this file is.
+
+    Returns:
+        An indexed path, for example ('foo/bar.txt', 5) returns:
+
+            foo/bar-00000005.txt
+    """
+    base_path, extension = os.path.splitext(sia_path)
+    return '%s-%08d%s' % (base_path, copy_index, extension)
 
 
 class Job(object):

--- a/sia_load_tester/main.py
+++ b/sia_load_tester/main.py
@@ -47,7 +47,7 @@ def main(args):
     contracts.ensure_min_contracts()
 
     input_dataset = dataset.load_from_path(args.dataset_root)
-    upload_jobs = jobs.from_dataset(input_dataset)
+    upload_jobs = jobs.from_dataset(input_dataset, args.dataset_copies)
     queue = upload_queue.from_upload_jobs(upload_jobs)
 
     exit_event = threading.Event()
@@ -74,6 +74,12 @@ if __name__ == '__main__':
         '--dataset_root',
         required=True,
         help='Path to root directory of data to upload to Sia')
+    parser.add_argument(
+        '-n',
+        '--dataset_copies',
+        default=1,
+        type=int,
+        help='The number of times to upload each input file to Sia')
     parser.add_argument(
         '-o',
         '--output_dir',


### PR DESCRIPTION
This flag allows the user to tell sia_load_tester to upload a single local file
to Sia multiple times under different Sia paths.